### PR TITLE
Provide xml:base, avoid Self Document Reference

### DIFF
--- a/template/atom.ht
+++ b/template/atom.ht
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<feed xmlns="http://www.w3.org/2005/Atom">
+<feed xmlns="http://www.w3.org/2005/Atom" xml:base="https://leahneukirchen.org/trivium/" >
   <title type="text">Trivium</title>
   <link rel="alternate" type="text/html"
-	href="https://leahneukirchen.org/trivium/" />
+	href="/" />
   <link rel="self" href="https://leahneukirchen.org/trivium/index.atom" />
   <author>
     <name>Leah Neukirchen</name>


### PR DESCRIPTION
xml:base to handle bluecloth's use of relative URL for images. Once xml:base is specified, need to also avoid Same Document Reference warning  https://validator.w3.org/feed/docs/warning/SameDocumentReference.html

Issue: https://github.com/leahneukirchen/trivium/issues/1